### PR TITLE
Fix: kda-configure-scaling.png shown as code, not image

### DIFF
--- a/workshop/content/flink-on-kda/deploy-to-kda/configure-kda-app.en.md
+++ b/workshop/content/flink-on-kda/deploy-to-kda/configure-kda-app.en.md
@@ -26,6 +26,6 @@ The skeleton of the application has now been created. But you still need to adap
 
 1. Expand the **Scaling** section and reduce the **Parallelism** to `1`
 
-        ![Configure Scaling](/images/flink-on-kda/kda-configure-scaling.png)
+	![Configure Scaling](/images/flink-on-kda/kda-configure-scaling.png)
 
 1. Keep the default settings **VPC Connectivity** and press the blue **Update** button at the bottom of the page to update the properties of the application


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
kda-configure-scaling.png shown as code, not image.
See: https://streaming-analytics.workshop.aws/flink-on-kda/deploy-to-kda/configure-kda-app.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
